### PR TITLE
fix(docker): don't fail release builds on GHA cache write errors

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -130,7 +130,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: a cache write is an optimization; the GHA cache
+          # service rejecting it ("failed to reserve cache") must not fail a
+          # release build. It killed the v0.2.0 publish twice on 2026-08-12.
+          cache-to: type=gha,mode=max,ignore-error=true
           # SLSA build provenance and an SBOM, attached to the image index as
           # attestation manifests (in addition to the cosign signature below).
           provenance: mode=max


### PR DESCRIPTION
The v0.2.0 publish failed twice with `error writing layer blob: failed to reserve cache` — the buildx `type=gha` cache **exporter** hard-fails the whole build when GitHub's cache service rejects a reservation. Cache writes are an optimization; `ignore-error=true` demotes the failure to a warning. Cache reads already fail soft.

After merge, the v0.2.0 image gets republished via the workflow-dispatch recovery knob (the release run's workflow snapshot predates this fix, so re-running it wouldn't pick it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
